### PR TITLE
Added Kerberos error to verbose failed authentication output

### DIFF
--- a/pre2k.py
+++ b/pre2k.py
@@ -420,12 +420,12 @@ def spray(cred, n, domain, ip, save, outputfile, accounts, status, sleep, jitter
     try:
         executer = GETTGT(username, password, domain, ip)
         validate = executer.run(save)
-    except KerberosError:
+    except KerberosError as kerberror:
         if verbose:
             if n:
-                line = (f'[-] Invalid credentials: {domain}\\{username}:nopass')
+                line = (f'[-] Invalid credentials: {domain}\\{username}:nopass. Error: {kerberror}')
             else:
-                line = (f'[-] Invalid credentials: {domain}\\{cred}')
+                line = (f'[-] Invalid credentials: {domain}\\{cred}. Error: {kerberror}')
             print (line)
             if outputfile:
                     printlog(line, outputfile)


### PR DESCRIPTION
Hello!

I've hit a couple of scenarios where requesting a ticket for a computer object fails not because of bad authentication/credentials, but because of another kerberos error (clock skew, hash type not supported, etc). This has tripped me up in the past where I've seen blank pwds in the DIT and had to come back to check with pre2k.

This PR just adds the kerberos error/exception to the Invalid Credentials line when the verbose flag is passed. It adds a little bit to the output text, but I've not had any problems with filtering the output file after the fact to find outliers from the standard KDC_ERR_PREAUTH_FAILED(Pre-authentication information was invalid).

This could also be cleaned up further by making the verbose flag action='count' and checking for over 2 or something like that to return the kerberos error in addition to the invalid creds error, or only the initial error if the count is 1.